### PR TITLE
Update rapidyaml to 0.8.0

### DIFF
--- a/bin/run-local.sh
+++ b/bin/run-local.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# example of running this:
+# set -xe ; ( cd ~/proj/yaml-runtimes ; make clean ; for proc in cpp-rapidengine cpp-rapidyaml ; do make $proc list-images ; make testv LIBRARY=$proc ; done ) ; ~/proj/yaml-test-matrix/bin/run-local.sh
+
+set -xe
+
+#procs="${1:-cpp-rapidengine.event cpp-rapidyaml.event cpp-rapidyaml.json cpp-rapidyaml.yaml}"
+procs="${1:-cpp-rapidengine.event cpp-rapidyaml.event cpp-rapidyaml.json}"
+
+ROOTDIR=$(dirname $(cd $(dirname $0) ; pwd))
+
+cd $ROOTDIR
+
+cpanm -l local YAML::XS
+cpanm -l local HTML::Template::Compiled
+export PERL5LIB=$PWD/local/lib/perl5
+
+make data
+make matrix
+make yaml-test-suite
+
+cp -fv ../yaml-runtimes/list.yaml .
+./bin/expected
+
+./bin/run-framework-tests -l
+for proc in $procs ; do
+    echo "processor: $proc"
+    ./bin/run-framework-tests --view $proc
+    ./bin/compare-framework-tests --view $proc
+done
+
+./bin/create-matrix
+./bin/highlight

--- a/lib/perl5/YAML/Matrix.pm
+++ b/lib/perl5/YAML/Matrix.pm
@@ -24,8 +24,7 @@ sub minimal_events_for_framework {
         $args{no_quoting_style} = 1;
     }
     elsif ($type eq 'rapid') {
-        $args{no_quoting_style} = 1;
-        $args{no_flow_indicator} = 1;
+        $args{no_explicit_doc} = 1;
     }
     elsif ($type eq 'flow') {
         $args{no_flow_indicator} = 1;
@@ -108,7 +107,7 @@ sub hsyaml_event_to_event {
 sub rapidyaml_event_to_event {
     my (@events) = @_;
     for my $event (@events) {
-        $event =~ s/^(\=VAL (&\S+ )?(<[^>]+> )?)["']/$1:/;
+        $event =~ s/^\+DOC ---/+DOC/;
     }
     return @events;
 }

--- a/ni.yaml
+++ b/ni.yaml
@@ -1,5 +1,10 @@
 ---
+c-libfyaml.event:       []
 c-libyaml.event:        [ empty-key ]
+cpp-rapidyaml.event:    [ complex-key, duplicate-key ]
+cpp-rapidyaml.yaml:     [ complex-key, duplicate-key ]
+cpp-rapidyaml.json:     [ complex-key, duplicate-key ]
+cpp-rapidengine.event:  [ duplicate-key ]
 dotnet-yamldotnet.json: [ local-tag, unknown-tag ]
 java-snakeyaml.event:   [ empty-key ]
 java-snakeyaml.json:    [ empty-key, local-tag, unknown-tag ]


### PR DESCRIPTION
Adjusted the workarounds as needed for the new version.
Also adds a helper script to facilitate building the matrix locally.